### PR TITLE
Average co2

### DIFF
--- a/AverageCO2Notes.md
+++ b/AverageCO2Notes.md
@@ -18,3 +18,6 @@
   - 3.3 kg CO2e washed at 60°C, dried in a combined washer-dryer
 
 - The kitchen sink is actually the source of the most water-related carbon emissions in the home. Keeping the kitchen tap running leads to approximately 157kg of CO2 being released per year while the dishwasher produces 142kg of CO2, the washing machine generates 118kg and the bath creates 103kg. (In a newer home, however, the shower is the water-use device with the highest emissions.)
+
+https://www.theguardian.com/environment/green-living-blog/2010/nov/25/carbon-footprint-load-laundry
+https://www.bbc.com/future/article/20200326-the-hidden-impact-of-your-daily-water-use

--- a/AverageCO2Notes.md
+++ b/AverageCO2Notes.md
@@ -1,0 +1,20 @@
+- Taking five minute showers for a whole year would save as much CO2 as is sequestered annually by half an acre of U.S. forest.
+
+| Shower time | 1 Minute | 2 Minutes | 3 Minutes | 4 Minutes | 5 Minutes |
+| ----------- | -------- | --------- | --------- | --------- | --------- |
+| CO2 grams   | 204.1    | 408.2     | 612.4     | 816.5     | 1020.6    |
+
+- Taking only five minute showers for the next 30 days would save 108 lbs of CO2, which is more than what a tree seedlings grown for 10 years can sequester (1.27 times more to be precise)!
+
+- Domestic laundry has a surprisingly large carbon footprint. The power needed to run household appliances, and especially the energy required to heat up water, has a carbon footprint that’s largely invisible to householders. Yet all of our water use adds up. It accounts for 6% of all carbon dioxide (CO2) emissions in the UK.
+
+- The bulk of the emissions from household water use, comes from the energy needed to heat water in the home, about 46% if a gas boiler is used. About 17% of the emissions come from using dishwashers, and 11% from washing machines.
+
+- The carbon footprint of a load of laundry:
+
+  - 0.6 kg CO2e washed at 30°C, dried on the line
+  - 0.7 kg CO2e washed at 40°C, dried on the line
+  - 2.4 kg CO2e washed at 40°C, tumble-dried in a vented dryer
+  - 3.3 kg CO2e washed at 60°C, dried in a combined washer-dryer
+
+- The kitchen sink is actually the source of the most water-related carbon emissions in the home. Keeping the kitchen tap running leads to approximately 157kg of CO2 being released per year while the dishwasher produces 142kg of CO2, the washing machine generates 118kg and the bath creates 103kg. (In a newer home, however, the shower is the water-use device with the highest emissions.)

--- a/__tests__/EmissionsCalculation.spec.js
+++ b/__tests__/EmissionsCalculation.spec.js
@@ -1,11 +1,15 @@
 import emissionsCalculator from '../src/logic/EmissionsCalculation';
 
 describe('EmissionsCalculator', () => {
-  it('return 1g for 1, 1', () => {
-    expect(emissionsCalculator(1, 1)).toEqual(1);
+  it('return 1kg for 1, 1000', () => {
+    expect(emissionsCalculator(1, 1000)).toEqual(1);
   });
 
-  it('returns 100 for 100, 1', () => {
-    expect(emissionsCalculator(100, 1)).toEqual(100);
+  it('returns 10kg for 1, 10000', () => {
+    expect(emissionsCalculator(1, 10000)).toEqual(10);
+  });
+
+  it('returns 100kg for 10, 10000', () => {
+    expect(emissionsCalculator(10, 10000)).toEqual(100);
   });
 });

--- a/__tests__/MilesToKilometres.spec.js
+++ b/__tests__/MilesToKilometres.spec.js
@@ -6,6 +6,6 @@ describe('MilesToKilometres', () => {
   });
 
   it('returns the equivalent value in km when passed true and a number', () => {
-    expect(milesToKilometres(true, 100)).toEqual(161);
+    expect(milesToKilometres(true, 100)).toEqual(160.9);
   });
 });

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -8,7 +8,11 @@ describe('ResultsMessage', () => {
   const microwave = context("using the microwave")
   const dishwasher = context("using the dishwasher")
   const weekendTV = context("a weekend watching TV")
-  const showering = context("showering every day for a week")
+  const showering = context("showering every day for a week or producing 1L of dairy milk")
+  const trainJourney = context("a 4hr train journey or producing a block of cheese")
+  const beefSteak = context("producing a beef steak")
+  const eurostar = context("a round trip to France using the Eurostar")
+  const londonDublin = context("London to Dublin by train/ferry or a flight from London to Leeds")
 
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
@@ -40,6 +44,22 @@ describe('ResultsMessage', () => {
 
   it('Compares users emissions to showering every day for a week', () => {
     expect(resultsMessage(3.5)).toEqual(showering)
+  })
+
+  it('Compares users emissions to a 4hr train journey', () => {
+    expect(resultsMessage(7.5)).toEqual(trainJourney)
+  })
+
+  it('Compares users emissions to producing a beef steak', () => {
+    expect(resultsMessage(15)).toEqual(beefSteak)
+  })
+
+  it('Compares users emissions to a trip to France using the Eurostar', () => {
+    expect(resultsMessage(35)).toEqual(eurostar)
+  })
+
+  it('Compares users emissions to a trip from London to Dublin using train and ferry', () => {
+    expect(resultsMessage(75)).toEqual(londonDublin)
   })
 });
 

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -1,11 +1,18 @@
-import resultsMessage from '../src/logic/ResultsMessage';
+import resultsMessage  from '../src/logic/ResultsMessage';
 
 describe('ResultsMessage', () => {
   const compliment = "Well done! Thanks for thinking about the planet"
-
+  const kettleTube = context("boiling a kettle or watching 10hrs of YouTube")
+  
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
   });
 
-
+  it('Compares users emissions to boiling the kettle', () => {
+    expect(resultsMessage(0.05)).toEqual(kettleTube);
+  });
 });
+
+function context(comparison) {
+  return `This is equivalent to ${comparison}`
+}

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -1,0 +1,11 @@
+import resultsMessage from '../src/logic/ResultsMessage';
+
+describe('ResultsMessage', () => {
+  const compliment = "Well done! Thanks for thinking about the planet"
+
+  it('Compliments user if they have 0 emissions', () => {
+    expect(resultsMessage(0)).toEqual(compliment);
+  });
+
+
+});

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -17,6 +17,10 @@ describe('ResultsMessage', () => {
   const londonLisbon = context("a flight from London Heathrow to Lisbon")
   const bitcoin = context("a single bitcoin transaction")
   const bangladesh = context("the annual per capita CO2 emissions for a Bangladeshi person")
+  const cambodia = context("the annual per capita CO2 emissions for Cambodia")
+  const nicaragua = context("the annual per capita CO2 emissions for Nicaragua")
+  const reconsider = "Unless this journey is essential, please re-consider!"
+
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
   });
@@ -80,6 +84,19 @@ describe('ResultsMessage', () => {
   it('Compares users emissions to the annual per capita CO2 emissions for a Bangladeshi person', () => {
     expect(resultsMessage(450)).toEqual(bangladesh)
   })
+
+  it('Compares users emissions to the annual per capita CO2 emissions for Cambodia', () => {
+    expect(resultsMessage(700)).toEqual(cambodia)
+  })
+
+  it('Compares users emissions to the annual per capita CO2 emissions for Nicaragua', () => {
+    expect(resultsMessage(900)).toEqual(nicaragua)
+  })
+
+  it('Tells ths user that they should reconsider their journey', () => {
+    expect(resultsMessage(1001)).toEqual(reconsider)
+  })
+  
 });
 
 function context(comparison) {

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -1,4 +1,4 @@
-import resultsMessage  from '../src/logic/ResultsMessage';
+import { resultsMessage, context}  from '../src/logic/ResultsMessage';
 
 describe('ResultsMessage', () => {
   const compliment = "Well done! Thanks for thinking about the planet."
@@ -98,7 +98,3 @@ describe('ResultsMessage', () => {
   })
   
 });
-
-function context(comparison) {
-  return `This is equivalent to ${comparison}.`
-}

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -3,6 +3,9 @@ import resultsMessage  from '../src/logic/ResultsMessage';
 describe('ResultsMessage', () => {
   const compliment = "Well done! Thanks for thinking about the planet"
   const kettleTube = context("boiling a kettle or watching 10hrs of YouTube")
+  const gasHob = context("an average meal being cooked on the hob")
+  const washingMachine = context("putting one load of laundry in the washing machine")
+  const microwave = context("using the micro wave")
   
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
@@ -10,6 +13,18 @@ describe('ResultsMessage', () => {
 
   it('Compares users emissions to boiling the kettle', () => {
     expect(resultsMessage(0.05)).toEqual(kettleTube);
+  });
+
+  it('Compares users emissions to gas hob', () => {
+    expect(resultsMessage(0.15)).toEqual(gasHob);
+  });
+
+  it('Compares users emissions to washing machine', () => {
+    expect(resultsMessage(0.25)).toEqual(washingMachine);
+  });
+
+  it('Compares users emissions to microwave', () => {
+    expect(resultsMessage(0.4)).toEqual(microwave);
   });
 });
 

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -1,12 +1,15 @@
 import resultsMessage  from '../src/logic/ResultsMessage';
 
 describe('ResultsMessage', () => {
-  const compliment = "Well done! Thanks for thinking about the planet"
+  const compliment = "Well done! Thanks for thinking about the planet."
   const kettleTube = context("boiling a kettle or watching 10hrs of YouTube")
   const gasHob = context("an average meal being cooked on the hob")
   const washingMachine = context("putting one load of laundry in the washing machine")
-  const microwave = context("using the micro wave")
-  
+  const microwave = context("using the microwave")
+  const dishwasher = context("using the dishwasher")
+  const weekendTV = context("a weekend watching TV")
+  const showering = context("showering every day for a week")
+
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
   });
@@ -26,8 +29,20 @@ describe('ResultsMessage', () => {
   it('Compares users emissions to microwave', () => {
     expect(resultsMessage(0.4)).toEqual(microwave);
   });
+
+  it('Compares users emissions to dishwasher', () => {
+    expect(resultsMessage(0.6)).toEqual(dishwasher)
+  });
+
+  it('Compares users emissions to a weekend of watching TV', () => {
+    expect(resultsMessage(1.5)).toEqual(weekendTV)
+  })
+
+  it('Compares users emissions to showering every day for a week', () => {
+    expect(resultsMessage(3.5)).toEqual(showering)
+  })
 });
 
 function context(comparison) {
-  return `This is equivalent to ${comparison}`
+  return `This is equivalent to ${comparison}.`
 }

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -19,7 +19,7 @@ describe('ResultsMessage', () => {
   const bangladesh = context("the annual per capita CO2 emissions for a Bangladeshi person")
   const cambodia = context("the annual per capita CO2 emissions for Cambodia")
   const nicaragua = context("the annual per capita CO2 emissions for Nicaragua")
-  const reconsider = "Unless this journey is essential, please re-consider!"
+  const reconsider = "Unless this journey is essential, please reconsider!"
 
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);

--- a/__tests__/ResultsMessage.spec.js
+++ b/__tests__/ResultsMessage.spec.js
@@ -12,8 +12,11 @@ describe('ResultsMessage', () => {
   const trainJourney = context("a 4hr train journey or producing a block of cheese")
   const beefSteak = context("producing a beef steak")
   const eurostar = context("a round trip to France using the Eurostar")
-  const londonDublin = context("London to Dublin by train/ferry or a flight from London to Leeds")
-
+  const londonDublin = context("a trip from London to Dublin by train/ferry or a flight from London to Leeds")
+  const londonEdinburgh = context("a flight from London Heathrow to Edinburgh")
+  const londonLisbon = context("a flight from London Heathrow to Lisbon")
+  const bitcoin = context("a single bitcoin transaction")
+  const bangladesh = context("the annual per capita CO2 emissions for a Bangladeshi person")
   it('Compliments user if they have 0 emissions', () => {
     expect(resultsMessage(0)).toEqual(compliment);
   });
@@ -60,6 +63,22 @@ describe('ResultsMessage', () => {
 
   it('Compares users emissions to a trip from London to Dublin using train and ferry', () => {
     expect(resultsMessage(75)).toEqual(londonDublin)
+  })
+
+  it('Compares users emissions to a trip from LHR to Edinburgh', () => {
+    expect(resultsMessage(150)).toEqual(londonEdinburgh)
+  })
+  
+  it('Compares users emissions to a trip from LHR to Lisbon', () => {
+    expect(resultsMessage(250)).toEqual(londonLisbon)
+  })
+
+  it('Compares users emissions to a single bitcoin transaction', () => {
+    expect(resultsMessage(350)).toEqual(bitcoin)
+  })
+
+  it('Compares users emissions to the annual per capita CO2 emissions for a Bangladeshi person', () => {
+    expect(resultsMessage(450)).toEqual(bangladesh)
   })
 });
 

--- a/src/logic/EmissionsCalculation.js
+++ b/src/logic/EmissionsCalculation.js
@@ -1,5 +1,6 @@
 function emissionsCalculator(co2Emissions, distance) {
-  return (co2Emissions * distance)/1000;
+  result = (co2Emissions * distance)/1000;
+  return parseFloat(result.toFixed(2))
 }
 
 export default emissionsCalculator;

--- a/src/logic/EmissionsCalculation.js
+++ b/src/logic/EmissionsCalculation.js
@@ -1,5 +1,5 @@
 function emissionsCalculator(co2Emissions, distance) {
-  return co2Emissions * distance;
+  return (co2Emissions * distance)/1000;
 }
 
 export default emissionsCalculator;

--- a/src/logic/MilesToKilometres.js
+++ b/src/logic/MilesToKilometres.js
@@ -1,6 +1,6 @@
 function milesToKilometres(value, distance) {
   if (value) {
-    return Math.round(distance * 1.609);
+    return distance * 1.609;
   }
 
   return distance;

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -23,7 +23,15 @@ function resultsMessage(result) {
     case(result < 50):
       return context("a round trip to France using the Eurostar")
     case(result < 100):
-      return context("London to Dublin by train/ferry or a flight from London to Leeds")
+      return context("a trip from London to Dublin by train/ferry or a flight from London to Leeds")
+    case(result < 200):
+      return context("a flight from London Heathrow to Edinburgh")
+    case(result < 300):
+      return context("a flight from London Heathrow to Lisbon")
+    case(result < 400):
+      return context("a single bitcoin transaction")
+    case(result < 500):
+      return context("the annual per capita CO2 emissions for a Bangladeshi person")
   }
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -4,11 +4,18 @@ function resultsMessage(result) {
       return "Well done! Thanks for thinking about the planet";
     case(result < 0.06):
       return context("boiling a kettle or watching 10hrs of YouTube")
+    case(result < 0.2):
+      return context("an average meal being cooked on the hob")
+    case(result < 0.3):
+      return context("putting one load of laundry in the washing machine")
+    case(result < 0.5):
+      return context("using the micro wave")
   }
 }
 
 export default resultsMessage 
-export function context(comparison) {
+
+function context(comparison) {
   return `This is equivalent to ${comparison}`
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -1,20 +1,14 @@
 function resultsMessage(result) {
-  switch (result) {
-    case 0:
-      return "Well done! Thanks for thinking about the planet"
+  switch (true) {
+    case(result === 0):
+      return "Well done! Thanks for thinking about the planet";
+    case(result < 0.06):
+      return context("boiling a kettle or watching 10hrs of YouTube")
   }
 }
 
 export default resultsMessage 
+export function context(comparison) {
+  return `This is equivalent to ${comparison}`
+}
 
-// switch (expr) {
-//   case 'Oranges':
-//     console.log('Oranges are $0.59 a pound.');
-//     break;
-//   case 'Mangoes':
-//   case 'Papayas':
-//     console.log('Mangoes and papayas are $2.79 a pound.');
-//     break;
-//   default:
-//     console.log(`Sorry, we are out of ${expr}.`);
-// }

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -37,7 +37,7 @@ export function resultsMessage(result) {
     case(result < 1000):
       return context("the annual per capita CO2 emissions for Nicaragua")
     case(result >= 1000):
-      return "Unless this journey is essential, please re-consider!"
+      return "Unless this journey is essential, please reconsider!"
   }
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -1,7 +1,7 @@
 function resultsMessage(result) {
   switch (true) {
     case(result === 0):
-      return "Well done! Thanks for thinking about the planet";
+      return "Well done! Thanks for thinking about the planet.";
     case(result < 0.06):
       return context("boiling a kettle or watching 10hrs of YouTube")
     case(result < 0.2):
@@ -9,13 +9,20 @@ function resultsMessage(result) {
     case(result < 0.3):
       return context("putting one load of laundry in the washing machine")
     case(result < 0.5):
-      return context("using the micro wave")
+      return context("using the microwave")
+    case(result < 0.7):
+      return context("using the dishwasher")
+    case(result < 2):
+      return context("a weekend watching TV")
+    case(result < 5):
+      return context("showering every day for a week")
+
   }
 }
 
 export default resultsMessage 
 
 function context(comparison) {
-  return `This is equivalent to ${comparison}`
+  return `This is equivalent to ${comparison}.`
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -32,6 +32,12 @@ function resultsMessage(result) {
       return context("a single bitcoin transaction")
     case(result < 500):
       return context("the annual per capita CO2 emissions for a Bangladeshi person")
+    case(result < 800):
+      return context("the annual per capita CO2 emissions for Cambodia")
+    case(result < 1000):
+      return context("the annual per capita CO2 emissions for Nicaragua")
+    case(result >= 1000):
+      return "Unless this journey is essential, please re-consider!"
   }
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -15,8 +15,15 @@ function resultsMessage(result) {
     case(result < 2):
       return context("a weekend watching TV")
     case(result < 5):
-      return context("showering every day for a week")
-
+      return context("showering every day for a week or producing 1L of dairy milk")
+    case(result < 10):
+      return context("a 4hr train journey or producing a block of cheese")
+    case(result < 20):
+      return context("producing a beef steak")
+    case(result < 50):
+      return context("a round trip to France using the Eurostar")
+    case(result < 100):
+      return context("London to Dublin by train/ferry or a flight from London to Leeds")
   }
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -1,4 +1,4 @@
-function resultsMessage(result) {
+export function resultsMessage(result) {
   switch (true) {
     case(result === 0):
       return "Well done! Thanks for thinking about the planet.";
@@ -41,9 +41,7 @@ function resultsMessage(result) {
   }
 }
 
-export default resultsMessage 
-
-function context(comparison) {
+export function context(comparison) {
   return `This is equivalent to ${comparison}.`
 }
 

--- a/src/logic/ResultsMessage.js
+++ b/src/logic/ResultsMessage.js
@@ -1,0 +1,20 @@
+function resultsMessage(result) {
+  switch (result) {
+    case 0:
+      return "Well done! Thanks for thinking about the planet"
+  }
+}
+
+export default resultsMessage 
+
+// switch (expr) {
+//   case 'Oranges':
+//     console.log('Oranges are $0.59 a pound.');
+//     break;
+//   case 'Mangoes':
+//   case 'Papayas':
+//     console.log('Mangoes and papayas are $2.79 a pound.');
+//     break;
+//   default:
+//     console.log(`Sorry, we are out of ${expr}.`);
+// }

--- a/src/screens/ResultsScreen.js
+++ b/src/screens/ResultsScreen.js
@@ -1,14 +1,18 @@
 import { StyleSheet, Text, View } from 'react-native';
 import React from 'react';
 import emissionsCalculator from '../logic/EmissionsCalculation';
+import { resultsMessage, context } from '../logic/ResultsMessage';
 
 const ResultsScreen = ({ route }) => {
   const { convertedDistance, emissions } = route.params;
   const result = emissionsCalculator(emissions, convertedDistance);
+  const comparison = resultsMessage(result);
 
   return (
     <View style={styles.container}>
       <Text>Your journey will release {result} kilograms of CO2.</Text>
+      <Text>{'\n'}</Text>
+      <Text>{comparison}</Text>
     </View>
   );
 };

--- a/src/screens/ResultsScreen.js
+++ b/src/screens/ResultsScreen.js
@@ -8,7 +8,7 @@ const ResultsScreen = ({ route }) => {
 
   return (
     <View style={styles.container}>
-      <Text>Your journey will release {result} grams of CO2.</Text>
+      <Text>Your journey will release {result} kilograms of CO2.</Text>
     </View>
   );
 };


### PR DESCRIPTION
Context was added, so when the emissions are calculated, there is a small bit of context given to show what their carbon emissions are equal to. 

We changed the ending result to be in Kilograms as apposed to grams.

And we also fixed the bug in which smaller amounts were not being calculated, we did this so that it would work with our contexts. The result will be given to two decimal places, regardless of the amount of zeros. Also please note that the calculations are `distance * 1.609` this can change the result by a decent amount.

Tickets completed in this pull request:
https://trello.com/c/bVt2ZCac/32-adding-context-logic-to-the-results-page
https://trello.com/c/bL0DOyA2/34-fixing-bug-on-api